### PR TITLE
Fix Windows MCP stdio and cross-platform Python backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Environment variables (all optional):
 |----------|---------|-------------|
 | `ANYMATE_CLAUDE_DIR` | `~/.claude` | Base directory for Claude Code teams/inboxes |
 | `ANYMATE_POLL_INTERVAL` | `1.0` | Inbox polling interval in seconds |
-| `ANYMATE_PYTHON` | `python3` | Python binary for the python-repl backend |
+| `ANYMATE_PYTHON` | current Python executable | Python binary for the python-repl backend |
 
 ## Project Structure
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -121,7 +121,7 @@ Claude：[通过 SendMessage 发送消息给 py]
 |------|--------|------|
 | `ANYMATE_CLAUDE_DIR` | `~/.claude` | Claude Code 团队和信箱的根目录 |
 | `ANYMATE_POLL_INTERVAL` | `1.0` | 信箱轮询间隔（秒） |
-| `ANYMATE_PYTHON` | `python3` | python-repl 后端使用的 Python 可执行文件 |
+| `ANYMATE_PYTHON` | 当前 Python 可执行文件 | python-repl 后端使用的 Python 可执行文件 |
 
 ## 项目结构
 

--- a/src/anymate/backends/python_repl.py
+++ b/src/anymate/backends/python_repl.py
@@ -1,6 +1,8 @@
 """Python REPL backend for AnyMate-CC."""
 import asyncio
+import os
 import shutil
+import sys
 import uuid
 from .base import Backend, BridgeSession, BackendCapabilities, BackendStatus, OutputCallback
 
@@ -34,11 +36,32 @@ while True:
     print(SENTINEL, file=sys.stdout, flush=True)
 '''
 
+
+def _resolve_python_binary(explicit: str | None = None) -> str:
+    if explicit:
+        return explicit
+    env_python = os.environ.get("ANYMATE_PYTHON")
+    if env_python:
+        return env_python
+    if sys.executable:
+        return sys.executable
+    if shutil.which("python3"):
+        return "python3"
+    return "python"
+
+
 class PythonReplSession(BridgeSession):
-    def __init__(self, name: str, team_name: str, cwd: str, python_binary: str = "python3", on_output: OutputCallback | None = None):
+    def __init__(
+        self,
+        name: str,
+        team_name: str,
+        cwd: str,
+        python_binary: str | None = None,
+        on_output: OutputCallback | None = None,
+    ):
         super().__init__(name, team_name, on_output)
         self._cwd = cwd
-        self._python = python_binary
+        self._python = _resolve_python_binary(python_binary)
         self._sentinel = f"__ANYMATE_DONE_{uuid.uuid4().hex[:8]}"
         self._process: asyncio.subprocess.Process | None = None
         self._read_task: asyncio.Task | None = None
@@ -66,7 +89,7 @@ class PythonReplSession(BridgeSession):
                 raw = await asyncio.wait_for(self._process.stdout.readline(), timeout=120.0)
                 if not raw:
                     break
-                line = raw.decode("utf-8", errors="replace").rstrip("\n")
+                line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
                 if line == self._sentinel:
                     output = "\n".join(buffer).strip()
                     buffer.clear()
@@ -115,8 +138,8 @@ class PythonReplSession(BridgeSession):
 
 
 class PythonReplBackend(Backend):
-    def __init__(self, python_binary: str = "python3"):
-        self._python = python_binary
+    def __init__(self, python_binary: str | None = None):
+        self._python = _resolve_python_binary(python_binary)
 
     @property
     def name(self) -> str:
@@ -127,7 +150,7 @@ class PythonReplBackend(Backend):
         return BackendCapabilities(supports_streaming=True, supports_interrupt=True, is_conversational=True, supports_cwd=True)
 
     def is_available(self) -> bool:
-        return shutil.which(self._python) is not None
+        return shutil.which(self._python) is not None or os.path.isfile(self._python)
 
     def create_session(self, name, team_name, prompt, cwd, *, on_output=None, **kwargs):
         return PythonReplSession(name=name, team_name=team_name, cwd=cwd, python_binary=self._python, on_output=on_output)

--- a/src/anymate/backends/shell.py
+++ b/src/anymate/backends/shell.py
@@ -55,7 +55,7 @@ class ShellSession(BridgeSession):
                 )
                 if not raw:
                     break
-                line = raw.decode("utf-8", errors="replace").rstrip("\n")
+                line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
                 if line == self._sentinel:
                     output = "\n".join(buffer).strip()
                     buffer.clear()

--- a/src/anymate/config.py
+++ b/src/anymate/config.py
@@ -2,17 +2,22 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 import os
+import sys
+
+
+def _default_python_binary() -> str:
+    return os.environ.get("ANYMATE_PYTHON") or sys.executable or "python"
 
 @dataclass
 class AnyMateConfig:
     claude_dir: Path | None = None
     poll_interval: float = 1.0
-    python_binary: str = "python3"
+    python_binary: str = field(default_factory=_default_python_binary)
 
     @classmethod
     def from_env(cls) -> "AnyMateConfig":
         return cls(
             claude_dir=Path(os.environ["ANYMATE_CLAUDE_DIR"]) if "ANYMATE_CLAUDE_DIR" in os.environ else None,
             poll_interval=float(os.environ.get("ANYMATE_POLL_INTERVAL", "1.0")),
-            python_binary=os.environ.get("ANYMATE_PYTHON", "python3"),
+            python_binary=os.environ.get("ANYMATE_PYTHON") or sys.executable or "python",
         )

--- a/src/anymate/server.py
+++ b/src/anymate/server.py
@@ -147,16 +147,9 @@ class McpStdioServer:
         if self._on_startup:
             await self._on_startup()
 
-        loop = asyncio.get_running_loop()
-        reader = asyncio.StreamReader()
-        await loop.connect_read_pipe(
-            lambda: asyncio.StreamReaderProtocol(reader),
-            sys.stdin.buffer,
-        )
-
         try:
             while True:
-                raw = await reader.readline()
+                raw = await asyncio.to_thread(sys.stdin.buffer.readline)
                 if not raw:
                     break  # EOF
                 line = raw.decode("utf-8", errors="replace").strip()

--- a/test_e2e.py
+++ b/test_e2e.py
@@ -1,9 +1,5 @@
-"""End-to-end integration test: full MVP flow without MCP transport.
-
-Validates: team setup → spawn teammate → inbox relay → REPL eval/exec → reply delivery.
-"""
+"""End-to-end integration test for message bridge + python-repl backend."""
 import asyncio
-import json
 import shutil
 import sys
 import tempfile
@@ -12,150 +8,104 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 
-from anymate.protocol.paths import PathResolver
-from anymate.protocol.messaging import ensure_inbox, append_message, now_iso
-from anymate.protocol.fileops import atomic_write_json, locked_read_json
 from anymate.backends import get_backend
 from anymate.bridge import MessageBridge
+from anymate.protocol.fileops import atomic_write_json, locked_read_json
+from anymate.protocol.messaging import append_message, ensure_inbox, now_iso
+from anymate.protocol.paths import PathResolver
 
 
-async def main():
-    # ── Step 1: Create temporary team directory structure ──────────────
+async def _wait_for_reply(
+    paths: PathResolver,
+    team_name: str,
+    expected_from: str,
+    expected_text: str,
+    timeout: float = 8.0,
+) -> dict:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        inbox_data = locked_read_json(
+            paths.inbox_path(team_name, "team-lead"),
+            paths.inboxes_lock_path(team_name),
+        )
+        for msg in inbox_data or []:
+            text = msg.get("text", "")
+            if msg.get("from") == expected_from and not text.startswith("{") and expected_text in text:
+                return msg
+        await asyncio.sleep(0.2)
+    raise AssertionError(f"Timed out waiting for reply containing {expected_text!r}")
+
+
+async def _run_bridge_e2e() -> None:
     tmpdir = Path(tempfile.mkdtemp(prefix="anymate_e2e_"))
-    print(f"[SETUP] Temp dir: {tmpdir}")
+    bridge: MessageBridge | None = None
+    try:
+        paths = PathResolver(base_dir=tmpdir)
+        team_name = "test-team"
 
-    paths = PathResolver(base_dir=tmpdir)
-    team_name = "test-team"
-
-    # Create config.json with a lead member
-    config_dir = paths.team_dir(team_name)
-    config_dir.mkdir(parents=True, exist_ok=True)
-    initial_config = {
-        "team_name": team_name,
-        "members": [
+        config_dir = paths.team_dir(team_name)
+        config_dir.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(
+            paths.config_path(team_name),
             {
-                "agentId": "team-lead@test-team",
-                "name": "team-lead",
-                "agentType": "general-purpose",
-                "color": "blue",
-                "joinedAt": int(time.time() * 1000),
-                "isActive": True,
-            }
-        ],
-    }
-    atomic_write_json(paths.config_path(team_name), initial_config)
-
-    # Create inboxes directory and team-lead inbox
-    ensure_inbox(paths, team_name, "team-lead")
-    print("[PASS] Step 1: Team directory structure created")
-
-    # ── Step 2: Spawn python-repl teammate ────────────────────────────
-    backend = get_backend("python-repl")
-    assert backend is not None, "python-repl backend not found"
-    assert backend.is_available(), "python3 not available"
-
-    poll_interval = 0.3  # fast polling for test
-    bridge = MessageBridge(paths, team_name, poll_interval)
-    on_output = bridge._make_output_handler("py-repl", color="green")
-
-    session = backend.create_session(
-        name="py-repl",
-        team_name=team_name,
-        prompt="",
-        cwd=str(tmpdir),
-        on_output=on_output,
-    )
-
-    # Create py-repl inbox
-    ensure_inbox(paths, team_name, "py-repl")
-
-    # Start session and bridge
-    await session.start()
-    assert session.is_alive, "Session should be alive after start"
-    await bridge.register("py-repl", session)
-    await bridge.start()
-    print("[PASS] Step 2: py-repl spawned, bridge running")
-
-    # ── Step 3: Simulate team-lead sends "1+1" to py-repl ────────────
-    append_message(paths, team_name, "py-repl", {
-        "from": "team-lead",
-        "text": "1+1",
-        "timestamp": now_iso(),
-        "read": False,
-    })
-    print("[    ] Step 3: Sent '1+1' to py-repl inbox")
-
-    # ── Step 4: Wait for bridge poll → REPL eval → reply ─────────────
-    reply_found = False
-    for attempt in range(30):  # up to ~6 seconds
-        await asyncio.sleep(0.2)
-        inbox_data = locked_read_json(
-            paths.inbox_path(team_name, "team-lead"),
-            paths.inboxes_lock_path(team_name),
+                "team_name": team_name,
+                "members": [
+                    {
+                        "agentId": "team-lead@test-team",
+                        "name": "team-lead",
+                        "agentType": "general-purpose",
+                        "color": "blue",
+                        "joinedAt": int(time.time() * 1000),
+                        "isActive": True,
+                    }
+                ],
+            },
         )
-        if inbox_data:
-            # Look for a reply from py-repl (not idle notification)
-            for msg in inbox_data:
-                if msg.get("from") == "py-repl" and not msg.get("text", "").startswith("{"):
-                    assert "2" in msg["text"], f"Expected '2' in reply, got: {msg['text']!r}"
-                    reply_found = True
-                    print(f"[PASS] Steps 3-5: eval path — sent '1+1', got reply: {msg['text']!r}")
-                    break
-        if reply_found:
-            break
 
-    assert reply_found, "Timed out waiting for reply to '1+1'"
+        ensure_inbox(paths, team_name, "team-lead")
+        ensure_inbox(paths, team_name, "py-repl")
 
-    # ── Step 6: Test exec path — send "print('hello')" ───────────────
-    # Clear team-lead inbox for clean check
-    atomic_write_json(paths.inbox_path(team_name, "team-lead"), [])
+        backend = get_backend("python-repl")
+        assert backend is not None, "python-repl backend not found"
+        assert backend.is_available(), "python backend is not available in this environment"
 
-    append_message(paths, team_name, "py-repl", {
-        "from": "team-lead",
-        "text": "print('hello')",
-        "timestamp": now_iso(),
-        "read": False,
-    })
-    print("[    ] Step 6: Sent \"print('hello')\" to py-repl inbox")
-
-    reply_found = False
-    for attempt in range(30):
-        await asyncio.sleep(0.2)
-        inbox_data = locked_read_json(
-            paths.inbox_path(team_name, "team-lead"),
-            paths.inboxes_lock_path(team_name),
+        bridge = MessageBridge(paths, team_name, poll_interval=0.2)
+        on_output = bridge._make_output_handler("py-repl", color="green")
+        session = backend.create_session(
+            name="py-repl",
+            team_name=team_name,
+            prompt="",
+            cwd=str(tmpdir),
+            on_output=on_output,
         )
-        if inbox_data:
-            for msg in inbox_data:
-                if msg.get("from") == "py-repl" and not msg.get("text", "").startswith("{"):
-                    assert "hello" in msg["text"], f"Expected 'hello' in reply, got: {msg['text']!r}"
-                    reply_found = True
-                    print(f"[PASS] Step 6: exec path — sent \"print('hello')\", got reply: {msg['text']!r}")
-                    break
-        if reply_found:
-            break
 
-    assert reply_found, "Timed out waiting for reply to print('hello')"
+        await session.start()
+        await bridge.register("py-repl", session)
+        await bridge.start()
 
-    # ── Step 7: Cleanup ───────────────────────────────────────────────
-    await bridge.stop()
-    assert not session.is_alive, "Session should be stopped after bridge.stop()"
-    print("[PASS] Step 7: Bridge stopped, session cleaned up")
+        append_message(
+            paths,
+            team_name,
+            "py-repl",
+            {"from": "team-lead", "text": "1+1", "timestamp": now_iso(), "read": False},
+        )
+        first = await _wait_for_reply(paths, team_name, expected_from="py-repl", expected_text="2")
+        assert "2" in first["text"]
 
-    # Verify config.json is intact
-    final_config = locked_read_json(
-        paths.config_path(team_name),
-        paths.inboxes_lock_path(team_name),
-    )
-    assert final_config is not None, "config.json should still exist"
-    print(f"[PASS] Config intact: {len(final_config.get('members', []))} member(s)")
-
-    # Remove temp dir
-    shutil.rmtree(tmpdir)
-    print(f"[PASS] Temp dir cleaned: {tmpdir}")
-
-    print("\n===== ALL E2E TESTS PASSED =====")
+        atomic_write_json(paths.inbox_path(team_name, "team-lead"), [])
+        append_message(
+            paths,
+            team_name,
+            "py-repl",
+            {"from": "team-lead", "text": "print('hello')", "timestamp": now_iso(), "read": False},
+        )
+        second = await _wait_for_reply(paths, team_name, expected_from="py-repl", expected_text="hello")
+        assert "hello" in second["text"]
+    finally:
+        if bridge is not None:
+            await bridge.stop()
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-if __name__ == "__main__":
-    asyncio.run(main())
+def test_bridge_python_repl_roundtrip() -> None:
+    asyncio.run(_run_bridge_e2e())

--- a/test_mcp_e2e.py
+++ b/test_mcp_e2e.py
@@ -1,141 +1,192 @@
-#!/usr/bin/env python3
 """Full end-to-end test of AnyMate-CC MCP server via JSON-RPC."""
-import subprocess, json, time, os, shutil, sys
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
 
-HOME = os.path.expanduser("~")
-ANYMATE_SRC = os.path.join(HOME, "A137442/anymate-cc/src")
-sys.path.insert(0, ANYMATE_SRC)
 
-TEAM_NAME = "anymate-test-live"
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
-# Step 1: Ensure clean state
-team_dir = os.path.join(HOME, f".claude/teams/{TEAM_NAME}")
-if os.path.exists(team_dir):
-    shutil.rmtree(team_dir)
 
-# Create team directory structure (simulating Claude Code's TeamCreate)
-os.makedirs(os.path.join(team_dir, "inboxes"), exist_ok=True)
+def _read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
 
-config = {
-    "teamName": TEAM_NAME,
-    "members": [
-        {"name": "team-lead", "agentId": "lead-001", "agentType": "team-lead"}
-    ]
-}
-with open(os.path.join(team_dir, "config.json"), "w") as f:
-    json.dump(config, f, indent=2)
 
-lead_inbox = os.path.join(team_dir, "inboxes/team-lead.json")
-with open(lead_inbox, "w") as f:
-    json.dump([], f)
-
-print("✓ Step 1: Team directory created")
-
-# Step 2: Start MCP server
-env = os.environ.copy()
-env["PYTHONPATH"] = ANYMATE_SRC
-proc = subprocess.Popen(
-    ["python3", "-m", "anymate.server"],
-    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-    env=env, cwd=os.path.join(HOME, "A137442/anymate-cc")
-)
-print(f"✓ Step 2: MCP server started (PID: {proc.pid})")
-
-def send_rpc(method, params, req_id):
-    msg = json.dumps({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
-    proc.stdin.write((msg + "\n").encode())
+def _send_rpc(proc: subprocess.Popen, method: str, params: dict, req_id: int) -> dict:
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    request = json.dumps(
+        {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params},
+        ensure_ascii=False,
+    )
+    proc.stdin.write(request + "\n")
     proc.stdin.flush()
-    line = proc.stdout.readline().decode().strip()
-    return json.loads(line) if line else None
+    line = proc.stdout.readline()
+    if not line:
+        stderr_text = ""
+        if proc.stderr is not None:
+            stderr_text = proc.stderr.read() or ""
+        raise AssertionError(f"No JSON-RPC response from MCP server. stderr: {stderr_text}")
+    return json.loads(line.strip())
 
-# Step 3: Initialize
-resp = send_rpc("initialize", {
-    "protocolVersion": "2024-11-05",
-    "capabilities": {},
-    "clientInfo": {"name": "e2e-test", "version": "1.0"}
-}, 1)
-print(f"✓ Step 3: Initialize: {resp['result']['serverInfo']}")
 
-# Step 4: Spawn Python REPL teammate
-resp = send_rpc("tools/call", {
-    "name": "spawn_teammate",
-    "arguments": {"team_name": TEAM_NAME, "name": "py-calc", "backend_type": "python-repl"}
-}, 2)
-spawn_text = resp["result"]["content"][0]["text"]
-print(f"✓ Step 4: spawn_teammate → {spawn_text}")
+def _tool_payload(response: dict) -> dict:
+    return json.loads(response["result"]["content"][0]["text"])
 
-time.sleep(2)
 
-# Step 5: Check teammate
-resp = send_rpc("tools/call", {
-    "name": "check_teammate",
-    "arguments": {"team_name": TEAM_NAME, "name": "py-calc"}
-}, 3)
-check_text = resp["result"]["content"][0]["text"]
-print(f"✓ Step 5: check_teammate → {check_text}")
+def _wait_until(predicate, timeout: float = 10.0, interval: float = 0.2) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
 
-# Step 6: Verify config updated
-with open(os.path.join(team_dir, "config.json")) as f:
-    members = [m["name"] for m in json.load(f)["members"]]
-print(f"✓ Step 6: Config members: {members}")
 
-# Step 7: Send message to py-calc (simulating Claude Code's SendMessage)
-py_calc_inbox = os.path.join(team_dir, "inboxes/py-calc.json")
-assert os.path.exists(py_calc_inbox), "py-calc inbox not created!"
+def test_mcp_server_jsonrpc_e2e(tmp_path: Path) -> None:
+    team_name = "anymate-test-live"
+    repo_root = Path(__file__).resolve().parent
+    src_dir = repo_root / "src"
+    claude_dir = tmp_path / ".claude"
+    team_dir = claude_dir / "teams" / team_name
+    inbox_dir = team_dir / "inboxes"
+    inbox_dir.mkdir(parents=True, exist_ok=True)
 
-message = {"from": "team-lead", "to": "py-calc", "text": "print(2 ** 10)", "timestamp": time.time(), "read": False}
-with open(py_calc_inbox) as f:
-    inbox = json.load(f)
-inbox.append(message)
-with open(py_calc_inbox, "w") as f:
-    json.dump(inbox, f, indent=2)
-print("✓ Step 7: Sent 'print(2 ** 10)' to py-calc")
+    _write_json(
+        team_dir / "config.json",
+        {
+            "team_name": team_name,
+            "members": [
+                {
+                    "name": "team-lead",
+                    "agentId": "lead-001",
+                    "agentType": "team-lead",
+                    "isActive": True,
+                }
+            ],
+        },
+    )
+    _write_json(inbox_dir / "team-lead.json", [])
 
-# Step 8: Wait for bridge relay
-print("  ⏳ Waiting for bridge to relay message...")
-time.sleep(6)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir)
+    env["ANYMATE_CLAUDE_DIR"] = str(claude_dir)
+    env["ANYMATE_PYTHON"] = sys.executable
+    env["ANYMATE_POLL_INTERVAL"] = "0.2"
 
-with open(lead_inbox) as f:
-    lead_messages = json.load(f)
-print(f"✓ Step 8: Lead inbox has {len(lead_messages)} message(s):")
-for msg in lead_messages:
-    print(f"  [{msg.get('from','?')}]: {msg.get('text','')[:200]}")
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "anymate.server"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        cwd=str(repo_root),
+        env=env,
+    )
 
-# Step 9: Send eval expression
-message2 = {"from": "team-lead", "to": "py-calc", "text": "sum(range(1, 101))", "timestamp": time.time(), "read": False}
-with open(py_calc_inbox) as f:
-    inbox = json.load(f)
-inbox.append(message2)
-with open(py_calc_inbox, "w") as f:
-    json.dump(inbox, f, indent=2)
-print("✓ Step 9: Sent 'sum(range(1, 101))' to py-calc")
+    try:
+        initialize = _send_rpc(
+            proc,
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest-e2e", "version": "1.0"},
+            },
+            1,
+        )
+        assert initialize["result"]["serverInfo"]["name"] == "anymate-cc"
 
-time.sleep(6)
+        spawn_payload = _tool_payload(
+            _send_rpc(
+                proc,
+                "tools/call",
+                {
+                    "name": "spawn_teammate",
+                    "arguments": {
+                        "team_name": team_name,
+                        "name": "py-calc",
+                        "backend_type": "python-repl",
+                        "cwd": str(tmp_path),
+                    },
+                },
+                2,
+            )
+        )
+        assert spawn_payload["success"] is True
+        assert spawn_payload["name"] == "py-calc"
 
-with open(lead_inbox) as f:
-    lead_messages = json.load(f)
-print(f"✓ Step 10: Lead inbox now has {len(lead_messages)} message(s):")
-for msg in lead_messages:
-    print(f"  [{msg.get('from','?')}]: {msg.get('text','')[:200]}")
+        check_payload = _tool_payload(
+            _send_rpc(
+                proc,
+                "tools/call",
+                {"name": "check_teammate", "arguments": {"team_name": team_name, "name": "py-calc"}},
+                3,
+            )
+        )
+        assert check_payload["registered"] is True
+        assert check_payload["process_alive"] is True
 
-# Step 11: List teammates
-resp = send_rpc("tools/call", {
-    "name": "list_teammates",
-    "arguments": {"team_name": TEAM_NAME}
-}, 4)
-list_text = resp["result"]["content"][0]["text"]
-print(f"✓ Step 11: list_teammates → {list_text}")
+        py_calc_inbox = inbox_dir / "py-calc.json"
+        assert py_calc_inbox.exists()
 
-# Step 12: Stop teammate
-resp = send_rpc("tools/call", {
-    "name": "stop_teammate",
-    "arguments": {"team_name": TEAM_NAME, "name": "py-calc"}
-}, 5)
-stop_text = resp["result"]["content"][0]["text"]
-print(f"✓ Step 12: stop_teammate → {stop_text}")
+        incoming = _read_json(py_calc_inbox)
+        incoming.append(
+            {
+                "from": "team-lead",
+                "to": "py-calc",
+                "text": "print(2 ** 10)",
+                "timestamp": time.time(),
+                "read": False,
+            }
+        )
+        _write_json(py_calc_inbox, incoming)
 
-# Cleanup
-proc.stdin.close()
-proc.wait(timeout=5)
-shutil.rmtree(team_dir)
-print("\n🎉 All tests passed! Team directory cleaned up.")
+        lead_inbox = inbox_dir / "team-lead.json"
+
+        def _has_python_reply() -> bool:
+            messages = _read_json(lead_inbox)
+            for msg in messages:
+                text = msg.get("text", "")
+                if msg.get("from") == "py-calc" and not text.startswith("{") and "1024" in text:
+                    return True
+            return False
+
+        assert _wait_until(_has_python_reply, timeout=12.0), "Timed out waiting for py-calc reply"
+
+        list_payload = _tool_payload(
+            _send_rpc(
+                proc,
+                "tools/call",
+                {"name": "list_teammates", "arguments": {"team_name": team_name}},
+                4,
+            )
+        )
+        assert list_payload["count"] == 1
+        assert list_payload["teammates"][0]["name"] == "py-calc"
+
+        stop_payload = _tool_payload(
+            _send_rpc(
+                proc,
+                "tools/call",
+                {"name": "stop_teammate", "arguments": {"team_name": team_name, "name": "py-calc"}},
+                5,
+            )
+        )
+        assert stop_payload["success"] is True
+
+        config_after = _read_json(team_dir / "config.json")
+        member_names = [member.get("name") for member in config_after.get("members", [])]
+        assert "py-calc" not in member_names
+    finally:
+        if proc.stdin is not None and not proc.stdin.closed:
+            proc.stdin.close()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)


### PR DESCRIPTION
## Summary
- fix Windows sentinel parsing by normalizing `\r\n` in backend read loops
- fix MCP stdio server input handling by reading stdin via `asyncio.to_thread(...)` instead of `connect_read_pipe`
- make python backend interpreter selection cross-platform (`ANYMATE_PYTHON` -> `sys.executable` -> `python3/python`)
- convert `test_e2e.py` and `test_mcp_e2e.py` into real pytest tests (no import-time side effects)
- update README defaults for `ANYMATE_PYTHON`

## Validation
- `pytest -q` => `2 passed`

## Impact
- resolves Windows hang/failure in MCP JSON-RPC E2E flow
- keeps Linux/macOS behavior unchanged while improving portability
